### PR TITLE
Add locked field to feeds for sync user permission control

### DIFF
--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -280,6 +280,9 @@ class FeedsController extends AppController
                 if (empty($feed['Feed']['lookup_visible'])) {
                     $feed['Feed']['lookup_visible'] = 0;
                 }
+                if (empty($feed['Feed']['locked'])) {
+                    $feed['Feed']['locked'] = 0;
+                }
                 if (empty($feed['Feed']['input_source'])) {
                     $feed['Feed']['input_source'] = 'network';
                 } else {
@@ -379,7 +382,8 @@ class FeedsController extends AppController
                 'lookup_visible',
                 'headers',
                 'orgc_id',
-                'fixed_event'
+                'fixed_event',
+                'locked'
             ],
             'afterFind' => function (array $feed) {
                 $feed['Feed']['settings'] = json_decode($feed['Feed']['settings'], true);

--- a/app/Controller/FeedsController.php
+++ b/app/Controller/FeedsController.php
@@ -280,8 +280,8 @@ class FeedsController extends AppController
                 if (empty($feed['Feed']['lookup_visible'])) {
                     $feed['Feed']['lookup_visible'] = 0;
                 }
-                if (empty($feed['Feed']['locked'])) {
-                    $feed['Feed']['locked'] = 0;
+                if (empty($feed['Feed']['lock_events'])) {
+                    $feed['Feed']['lock_events'] = 0;
                 }
                 if (empty($feed['Feed']['input_source'])) {
                     $feed['Feed']['input_source'] = 'network';
@@ -383,7 +383,7 @@ class FeedsController extends AppController
                 'headers',
                 'orgc_id',
                 'fixed_event',
-                'locked'
+                'lock_events'
             ],
             'afterFind' => function (array $feed) {
                 $feed['Feed']['settings'] = json_decode($feed['Feed']['settings'], true);

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -2480,6 +2480,9 @@ class AppModel extends Model
             case 140:
                 $sqlArray[] = "ALTER TABLE `taxii_servers` MODIFY `api_key` TEXT NOT NULL";
                 break;
+            case 141:
+                $sqlArray[] = "ALTER TABLE `feeds` ADD `locked` tinyint(1) NOT NULL DEFAULT 0;";
+                break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';
                 $sqlArray[] = 'UPDATE `attributes` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -95,7 +95,8 @@ class AppModel extends Model
         117 => false, 118 => false, 119 => false, 120 => false, 121 => false, 122 => false,
         123 => false, 124 => false, 125 => false, 126 => false, 127 => false, 128 => false,
         129 => false, 130 => false, 131 => false, 132 => false, 133 => false, 134 => true,
-        135 => false, 136 => true, 137 => false, 138 => false, 139 => false, 140 => false
+	135 => false, 136 => true, 137 => false, 138 => false, 139 => false, 140 => false,
+        141 => false
     );
 
     const ADVANCED_UPDATES_DESCRIPTION = array(

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -2482,7 +2482,7 @@ class AppModel extends Model
                 $sqlArray[] = "ALTER TABLE `taxii_servers` MODIFY `api_key` TEXT NOT NULL";
                 break;
             case 141:
-                $sqlArray[] = "ALTER TABLE `feeds` ADD `locked` tinyint(1) NOT NULL DEFAULT 0;";
+                $sqlArray[] = "ALTER TABLE `feeds` ADD `lock_events` tinyint(1) NOT NULL DEFAULT 0;";
                 break;
             case 'fixNonEmptySharingGroupID':
                 $sqlArray[] = 'UPDATE `events` SET `sharing_group_id` = 0 WHERE `distribution` != 4;';

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -95,7 +95,7 @@ class AppModel extends Model
         117 => false, 118 => false, 119 => false, 120 => false, 121 => false, 122 => false,
         123 => false, 124 => false, 125 => false, 126 => false, 127 => false, 128 => false,
         129 => false, 130 => false, 131 => false, 132 => false, 133 => false, 134 => true,
-	135 => false, 136 => true, 137 => false, 138 => false, 139 => false, 140 => false,
+        135 => false, 136 => true, 137 => false, 138 => false, 139 => false, 140 => false,
         141 => false
     );
 

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -1061,6 +1061,7 @@ class Feed extends AppModel
             } else {
                 $event['Event']['distribution'] = $feed['Feed']['distribution'];
                 $event['Event']['sharing_group_id'] = $feed['Feed']['sharing_group_id'];
+                $event['Event']['locked'] = !empty($feed['Feed']['locked']) ? 1 : 0;
                 if ($feed['Feed']['sharing_group_id']) {
                     $sg = $this->SharingGroup->find('first', array(
                         'recursive' => -1,

--- a/app/Model/Feed.php
+++ b/app/Model/Feed.php
@@ -1061,7 +1061,7 @@ class Feed extends AppModel
             } else {
                 $event['Event']['distribution'] = $feed['Feed']['distribution'];
                 $event['Event']['sharing_group_id'] = $feed['Feed']['sharing_group_id'];
-                $event['Event']['locked'] = !empty($feed['Feed']['locked']) ? 1 : 0;
+                $event['Event']['lock_events'] = !empty($feed['Feed']['lock_events']) ? 1 : 0;
                 if ($feed['Feed']['sharing_group_id']) {
                     $sg = $this->SharingGroup->find('first', array(
                         'recursive' => -1,

--- a/app/View/Feeds/add.ctp
+++ b/app/View/Feeds/add.ctp
@@ -32,6 +32,12 @@ echo $this->element('genericElements/Form/genericForm', [
                 'type' => 'checkbox'
             ],
             [
+                'field' => 'locked',
+                'label' => __('Lock events'),
+                'title' => __('Lock events created from this feed (allows sync users to edit them)'),
+                'type' => 'checkbox'
+            ],
+            [
                 'field' => 'name',
                 'label' => __('Name'),
                 'placeholder' => __('Feed name'),

--- a/app/View/Feeds/add.ctp
+++ b/app/View/Feeds/add.ctp
@@ -32,7 +32,7 @@ echo $this->element('genericElements/Form/genericForm', [
                 'type' => 'checkbox'
             ],
             [
-                'field' => 'locked',
+                'field' => 'lock_events',
                 'label' => __('Lock events'),
                 'title' => __('Lock events created from this feed (allows sync users to edit them)'),
                 'type' => 'checkbox'

--- a/db_schema.json
+++ b/db_schema.json
@@ -3478,6 +3478,17 @@
                 "column_type": "int(11)",
                 "column_default": "0",
                 "extra": ""
+            },
+            {
+                "column_name": "locked",
+                "is_nullable": "NO",
+                "data_type": "tinyint",
+                "character_maximum_length": null,
+                "numeric_precision": "3",
+                "collation_name": null,
+                "column_type": "tinyint(1)",
+                "column_default": "0",
+                "extra": ""
             }
         ],
         "fuzzy_correlate_ssdeep": [

--- a/db_schema.json
+++ b/db_schema.json
@@ -3480,7 +3480,7 @@
                 "extra": ""
             },
             {
-                "column_name": "locked",
+                "column_name": "lock_events",
                 "is_nullable": "NO",
                 "data_type": "tinyint",
                 "character_maximum_length": null,


### PR DESCRIPTION
- Add database migration case 141 for feeds.locked field
- Modify feed processing to set event locked status from feed config
- Add locked checkbox to feed add/edit UI forms
- Update controller to handle locked field in save operations

Fixes sync user permission issue where users could pull feed events but not update them. Events from locked feeds can now be edited by sync users, while unlocked feeds remain local-only.

Addresses GitHub issue #10047

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2020-05-05: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
